### PR TITLE
Settings: Modify RU translation for Ambient display

### DIFF
--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -867,7 +867,7 @@
     <string name="screensaver_settings_button" msgid="7292214707625717013">"Настройки"</string>
     <string name="automatic_brightness" msgid="5014143533884135461">"Автонастройка"</string>
     <string name="lift_to_wake_title" msgid="4555378006856277635">"Активация в вертикальном положении"</string>
-    <string name="doze_title" msgid="2259176504273878294">"Запрет спящего режима"</string>
+    <string name="doze_title" msgid="2259176504273878294">"Индикация событий"</string>
     <string name="doze_summary" msgid="7128970177894383698">"Включение дисплея, когда вы берете устройство в руки или получаете уведомление"</string>
     <string name="title_font_size" msgid="4405544325522105222">"Размер шрифта"</string>
     <string name="dialog_title_font_size" msgid="2231507851258955038">"Размер шрифта"</string>


### PR DESCRIPTION
Requested by Vitaly K. Current Google translation is "Disable sleep mode",
which is incorrect and misleading.

Change-Id: I936ff66ce8f9d89ab910dae88971a8a589f6584e