### PR TITLE
Settings: ask telephony for network selection

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -44,44 +44,6 @@
         <item>DEFAULT</item>
     </string-array>
 
-    <!-- Profile 2G-3G and 4G mode options. -->
-    <string-array name="profile_networkmode_entries_4g" translatable="false">
-        <item>@string/profile_networkmode_2g</item>
-        <item>@string/profile_networkmode_3g</item>
-        <item>@string/profile_networkmode_4g</item>
-        <item>@string/profile_networkmode_2g3g</item>
-        <item>@string/profile_networkmode_2g3g4g</item>
-        <item>@string/profile_action_none</item>
-    </string-array>
-
-    <!-- Profile 2G-3G and 4G mode values. -->
-    <string-array name="profile_networkmode_values_4g" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-    </string-array>
-
-    <!-- Profile 2G-3G and 4G mode options. -->
-    <string-array name="profile_networkmode_entries_no_2g" translatable="false">
-        <item>@string/profile_networkmode_3g</item>
-        <item>@string/profile_networkmode_4g</item>
-        <item>@string/profile_networkmode_2g3g</item>
-        <item>@string/profile_networkmode_2g3g4g</item>
-        <item>@string/profile_action_none</item>
-    </string-array>
-
-    <!-- Profile 2G-3G and 4G mode values. -->
-    <string-array name="profile_networkmode_values_no_2g" translatable="false">
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-    </string-array>
-
     <!-- Profile lock mode summaries. Do not translate. -->
     <string-array name="profile_lockmode_entries" translatable="false">
         <item>@string/profile_action_system</item>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -197,6 +197,7 @@
     <string name="toggleData">Data connection</string>
     <string name="toggleSync">Auto-sync data</string>
     <string name="toggle2g3g4g">Preferred network type</string>
+    <string name="toggle2g3g4g_msim">Preferred network type (%1$s)</string>
     <string name="toggleNfc">NFC</string>
 
     <!-- Wi-Fi region code -->

--- a/src/com/android/settings/profiles/SetupActionsFragment.java
+++ b/src/com/android/settings/profiles/SetupActionsFragment.java
@@ -25,7 +25,6 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.location.LocationManager;
 import android.media.AudioManager;
 import android.media.RingtoneManager;
@@ -37,6 +36,8 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.SeekBarVolumizer;
 import android.provider.Settings;
+import android.telephony.SubscriptionInfo;
+import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 import android.text.Editable;
 import android.text.TextUtils;
@@ -67,7 +68,6 @@ import cyanogenmod.profiles.RingModeSettings;
 import cyanogenmod.profiles.StreamSettings;
 
 import com.android.settings.R;
-import com.android.settings.SettingsActivity;
 import com.android.settings.SubSettings;
 import com.android.settings.cyanogenmod.DeviceUtils;
 import com.android.settings.SettingsPreferenceFragment;
@@ -87,6 +87,7 @@ import com.android.settings.profiles.actions.item.RingModeItem;
 import com.android.settings.profiles.actions.item.TriggerItem;
 import com.android.settings.profiles.actions.item.VolumeStreamItem;
 import com.android.settings.Utils;
+import com.android.settings.utils.TelephonyUtils;
 import org.cyanogenmod.internal.logging.CMMetricsLogger;
 
 import java.util.ArrayList;
@@ -100,13 +101,15 @@ import static cyanogenmod.profiles.ConnectionSettings.PROFILE_CONNECTION_NFC;
 import static cyanogenmod.profiles.ConnectionSettings.PROFILE_CONNECTION_SYNC;
 import static cyanogenmod.profiles.ConnectionSettings.PROFILE_CONNECTION_WIFI;
 import static cyanogenmod.profiles.ConnectionSettings.PROFILE_CONNECTION_WIFIAP;
-import static cyanogenmod.profiles.ConnectionSettings.PROFILE_CONNECTION_WIMAX;
 
 public class SetupActionsFragment extends SettingsPreferenceFragment
         implements AdapterView.OnItemClickListener {
 
     private static final int RINGTONE_REQUEST_CODE = 1000;
     private static final int NEW_TRIGGER_REQUEST_CODE = 1001;
+    private static final int SET_NETWORK_MODE_REQUEST_CODE = 1002;
+
+    public static final String EXTRA_NETWORK_MODE_PICKED = "network_mode_picker::chosen_value";
 
     private static final int MENU_REMOVE = Menu.FIRST;
     private static final int MENU_FILL_PROFILE = Menu.FIRST + 1;
@@ -225,10 +228,17 @@ public class SetupActionsFragment extends SettingsPreferenceFragment
             mItems.add(generateConnectionOverrideItem(PROFILE_CONNECTION_MOBILEDATA));
             mItems.add(generateConnectionOverrideItem(PROFILE_CONNECTION_WIFIAP));
 
-            final TelephonyManager tm =
-                    (TelephonyManager) getActivity().getSystemService(Context.TELEPHONY_SERVICE);
-            if (tm.getPhoneType() == TelephonyManager.PHONE_TYPE_GSM) {
-                mItems.add(generateConnectionOverrideItem(PROFILE_CONNECTION_2G3G4G));
+            final List<SubscriptionInfo> subs = SubscriptionManager.from(getContext())
+                    .getActiveSubscriptionInfoList();
+            if (subs != null && subs.size() > 1) {
+                for (SubscriptionInfo sub : subs) {
+                    mItems.add(generatePreferredNetworkOverrideItem(sub.getSubscriptionId()));
+                }
+            } else {
+                if (TelephonyManager.from(getContext()).getPhoneCount() == 1) {
+                    mItems.add(generatePreferredNetworkOverrideItem(
+                            SubscriptionManager.INVALID_SUBSCRIPTION_ID));
+                }
             }
         }
         //if (WimaxHelper.isWimaxSupported(getActivity())) {
@@ -335,6 +345,16 @@ public class SetupActionsFragment extends SettingsPreferenceFragment
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private ConnectionOverrideItem generatePreferredNetworkOverrideItem(int subId) {
+        ConnectionSettings settings = mProfile.getConnectionSettingWithSubId(subId);
+        if (settings == null) {
+            settings = new ConnectionSettings(ConnectionSettings.PROFILE_CONNECTION_2G3G4G);
+            settings.setSubId(subId);
+            mProfile.setConnectionSettings(settings);
+        }
+        return new ConnectionOverrideItem(settings.getConnectionId(), settings);
     }
 
     private ConnectionOverrideItem generateConnectionOverrideItem(int connectionId) {
@@ -543,11 +563,7 @@ public class SetupActionsFragment extends SettingsPreferenceFragment
 
             case DIALOG_CONNECTION_OVERRIDE:
                 ConnectionOverrideItem connItem = (ConnectionOverrideItem) mSelectedItem;
-                if (connItem.getConnectionType() == ConnectionSettings.PROFILE_CONNECTION_2G3G4G) {
-                    return requestMobileConnectionOverrideDialog(connItem.getSettings());
-                } else {
-                    return requestConnectionOverrideDialog(connItem.getSettings());
-                }
+                return requestConnectionOverrideDialog(connItem.getSettings());
 
             case DIALOG_VOLUME_STREAM:
                 VolumeStreamItem volumeItem = (VolumeStreamItem) mSelectedItem;
@@ -744,6 +760,29 @@ public class SetupActionsFragment extends SettingsPreferenceFragment
         if (requestCode == NEW_TRIGGER_REQUEST_CODE) {
             mProfile = mProfileManager.getProfile(mProfile.getUuid());
             rebuildItemList();
+
+        } else if (requestCode == SET_NETWORK_MODE_REQUEST_CODE
+                && resultCode == Activity.RESULT_OK) {
+
+            int selectedMode = Integer.parseInt(data.getStringExtra(
+                    TelephonyUtils.EXTRA_NETWORK_PICKER_PICKED_VALUE));
+            int subId = data.getIntExtra(TelephonyUtils.EXTRA_SUBID,
+                    SubscriptionManager.getDefaultDataSubId());
+            ConnectionOverrideItem connItem = (ConnectionOverrideItem) mSelectedItem;
+            final ConnectionSettings setting = connItem.getSettings();
+//            final ConnectionSettings setting = mProfile.getConnectionSettingWithSubId(subId);
+
+            switch (selectedMode) {
+                case ConnectionOverrideItem.CM_MODE_SYSTEM_DEFAULT:
+                    setting.setOverride(false);
+                    break;
+                default:
+                    setting.setOverride(true);
+                    setting.setValue(selectedMode);
+            }
+            mProfile.setConnectionSettings(setting);
+            mAdapter.notifyDataSetChanged();
+            updateProfile();
         }
     }
 
@@ -802,6 +841,9 @@ public class SetupActionsFragment extends SettingsPreferenceFragment
         if (setting == null) {
             throw new UnsupportedOperationException("connection setting cannot be null");
         }
+        if (setting.getConnectionId() == PROFILE_CONNECTION_2G3G4G) {
+            throw new UnsupportedOperationException("dialog must be requested from Telephony");
+        }
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         final String[] connectionNames =
                 getResources().getStringArray(R.array.profile_action_generic_connection_entries);
@@ -815,7 +857,7 @@ public class SetupActionsFragment extends SettingsPreferenceFragment
             }
         }
 
-        builder.setTitle(ConnectionOverrideItem.getConnectionTitle(setting.getConnectionId()));
+        builder.setTitle(ConnectionOverrideItem.getConnectionTitle(getContext(), setting));
         builder.setSingleChoiceItems(connectionNames, defaultIndex,
                 new DialogInterface.OnClickListener() {
                     @Override
@@ -832,73 +874,6 @@ public class SetupActionsFragment extends SettingsPreferenceFragment
                                 setting.setOverride(true);
                                 setting.setValue(1);
                                 break;
-                        }
-                        mProfile.setConnectionSettings(setting);
-                        mAdapter.notifyDataSetChanged();
-                        updateProfile();
-                        dialog.dismiss();
-                    }
-                });
-
-        builder.setNegativeButton(android.R.string.cancel, null);
-        return builder.create();
-    }
-
-    private AlertDialog requestMobileConnectionOverrideDialog(final ConnectionSettings setting) {
-        if (setting == null) {
-            throw new UnsupportedOperationException("connection setting cannot be null");
-        }
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        boolean allow2g = true;
-
-        // config_prefer_2g in p/s/Telephony
-        // if false, 2g is not available.
-        try {
-            final Context telephonyContext = getActivity()
-                    .createPackageContext("com.android.phone", 0);
-            if (telephonyContext != null) {
-                int identifier = telephonyContext.getResources().getIdentifier("config_prefer_2g",
-                        "bool", telephonyContext.getPackageName());
-                if (identifier > 0) {
-                    allow2g = telephonyContext.getResources().getBoolean(identifier);
-                    android.util.Log.e("ro", "allow2g: " + allow2g);
-                }
-            }
-        } catch (PackageManager.NameNotFoundException e) {
-            // hmmm....
-        }
-
-        final String[] connectionNames =
-                getResources().getStringArray(allow2g ? R.array.profile_networkmode_entries_4g
-                        : R.array.profile_networkmode_entries_no_2g);
-        final String[] connectionValues =
-                getResources().getStringArray(allow2g ? R.array.profile_networkmode_values_4g
-                        : R.array.profile_networkmode_values_no_2g);
-
-        int defaultIndex = connectionValues.length - 1; // no action is the last
-        if (setting.isOverride()) {
-            // need to match the value
-            final int value = setting.getValue();
-            for (int i = 0; i < connectionValues.length; i++) {
-                if (Integer.parseInt(connectionValues[i]) == value) {
-                    defaultIndex = i;
-                    break;
-                }
-            }
-        }
-
-        builder.setTitle(ConnectionOverrideItem.getConnectionTitle(setting.getConnectionId()));
-        builder.setSingleChoiceItems(connectionNames, defaultIndex,
-                new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int item) {
-                        switch (item) {
-                            case ConnectionOverrideItem.CM_MODE_UNCHANGED:
-                                setting.setOverride(false);
-                                break;
-                            default:
-                                setting.setOverride(true);
-                                setting.setValue(Integer.parseInt(connectionValues[item]));
                         }
                         mProfile.setConnectionSettings(setting);
                         mAdapter.notifyDataSetChanged();
@@ -1133,7 +1108,21 @@ public class SetupActionsFragment extends SettingsPreferenceFragment
         } else if (itemAtPosition instanceof RingModeItem) {
             showDialog(DIALOG_RING_MODE);
         } else if (itemAtPosition instanceof ConnectionOverrideItem) {
-            showDialog(DIALOG_CONNECTION_OVERRIDE);
+
+            ConnectionOverrideItem connItem = (ConnectionOverrideItem) mSelectedItem;
+            if (connItem.getConnectionType() == ConnectionSettings.PROFILE_CONNECTION_2G3G4G) {
+                final Intent intent = new Intent(TelephonyUtils.ACTION_PICK_NETWORK_MODE);
+                intent.putExtra(TelephonyUtils.EXTRA_NONE_TEXT,
+                        getString(R.string.profile_action_none));
+                intent.putExtra(TelephonyUtils.EXTRA_SHOW_NONE, true);
+                intent.putExtra(TelephonyUtils.EXTRA_SUBID, connItem.getSettings().getSubId());
+                intent.putExtra(TelephonyUtils.EXTRA_INITIAL_NETWORK_VALUE,
+                        connItem.getSettings().isOverride()
+                                ? connItem.getSettings().getValue() : -1);
+                startActivityForResult(intent, SET_NETWORK_MODE_REQUEST_CODE);
+            } else {
+                showDialog(DIALOG_CONNECTION_OVERRIDE);
+            }
         } else if (itemAtPosition instanceof VolumeStreamItem) {
             showDialog(DIALOG_VOLUME_STREAM);
         } else if (itemAtPosition instanceof ProfileNameItem) {

--- a/src/com/android/settings/utils/TelephonyUtils.java
+++ b/src/com/android/settings/utils/TelephonyUtils.java
@@ -1,0 +1,231 @@
+package com.android.settings.utils;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.os.PersistableBundle;
+import android.telephony.CarrierConfigManager;
+import android.telephony.TelephonyManager;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.android.internal.telephony.PhoneConstants;
+import com.android.internal.telephony.RILConstants;
+
+/**
+ * Helper class which has the same logic as MobileNetworkSettings to display the same
+ * network modes and strings as it does.
+ */
+public class TelephonyUtils {
+
+    private static final String TAG = TelephonyUtils.class.getSimpleName();
+
+    // from MobileNetworkSettings
+    public static final String ACTION_PICK_NETWORK_MODE =
+            "cyanogenmod.platform.intent.action.NETWORK_MODE_PICKER";
+    public static final String EXTRA_NONE_TEXT = "network_mode_picker::neutral_text";
+    public static final String EXTRA_SHOW_NONE = "network_mode_picker::show_none";
+    public static final String EXTRA_INITIAL_NETWORK_VALUE = "network_mode_picker::selected_mode";
+    public static final String EXTRA_NETWORK_PICKER_PICKED_VALUE =
+            "network_mode_picker::chosen_value";
+    public static final String EXTRA_SUBID = "network_mode_picker::sub_id";
+
+    public static String getNetworkModeString(Context context, int networkMode, int subId) {
+        return getNetworkModeString(context,
+                networkMode,
+                TelephonyManager.from(context).getCurrentPhoneType(subId) /* phone type */,
+                show4GForLTE(context)/* show 4G for lte */,
+                isSupportTdscdma(context, subId)/* supports TDS CDMA*/,
+                isGlobalCDMA(context, subId, isLteOnCdma(context, subId))/* is Global cdma */,
+                isWorldMode(context)/* is worldwide */);
+    }
+
+    public static String getNetworkModeString(Context context, int networkMode,
+            int phoneType, boolean show4GForLTE, boolean isSupportTdsCdma, boolean isGlobalCdma,
+            boolean isWorldMode) {
+        String r = null;
+        switch (networkMode) {
+            case RILConstants.NETWORK_MODE_TDSCDMA_WCDMA:
+            case RILConstants.NETWORK_MODE_TDSCDMA_GSM_WCDMA:
+            case RILConstants.NETWORK_MODE_TDSCDMA_GSM:
+                r = "network_3G";
+                break;
+            case RILConstants.NETWORK_MODE_WCDMA_ONLY:
+                r = "network_wcdma_only";
+                break;
+            case RILConstants.NETWORK_MODE_GSM_UMTS:
+                r = "network_gsm_umts";
+                break;
+            case RILConstants.NETWORK_MODE_WCDMA_PREF:
+                r = "network_wcdma_pref";
+                break;
+            case RILConstants.NETWORK_MODE_GSM_ONLY:
+                r = "network_gsm_only";
+                break;
+            case RILConstants.NETWORK_MODE_LTE_GSM_WCDMA:
+                r = (show4GForLTE)
+                        ? "network_4G" : "network_lte_gsm_wcdma";
+                break;
+            case RILConstants.NETWORK_MODE_LTE_WCDMA:
+                r = (show4GForLTE)
+                        ? "network_4G" : "network_lte_cdma";
+                break;
+            case RILConstants.NETWORK_MODE_LTE_ONLY:
+                r = (show4GForLTE)
+                        ? "network_4G_only" : "network_lte_only";
+                break;
+            case RILConstants.NETWORK_MODE_LTE_CDMA_EVDO:
+                r = (show4GForLTE)
+                        ? "network_4G" : "network_lte_cdma_and_evdo";
+                break;
+            case RILConstants.NETWORK_MODE_TDSCDMA_CDMA_EVDO_GSM_WCDMA:
+                r = "network_3G";
+                break;
+            case RILConstants.NETWORK_MODE_CDMA:
+                r = "network_cdma";
+                break;
+            case RILConstants.NETWORK_MODE_EVDO_NO_CDMA:
+                r = "network_evdo_no_cdma";
+                break;
+            case RILConstants.NETWORK_MODE_GLOBAL:
+                r = "network_3g_global";
+                break;
+            case RILConstants.NETWORK_MODE_CDMA_NO_EVDO:
+                r = "network_cdma_no_evdo";
+                break;
+            case RILConstants.NETWORK_MODE_TDSCDMA_ONLY:
+                r = "network_tdscdma";
+                break;
+            case RILConstants.NETWORK_MODE_LTE_TDSCDMA_GSM:
+            case RILConstants.NETWORK_MODE_LTE_TDSCDMA_GSM_WCDMA:
+            case RILConstants.NETWORK_MODE_LTE_TDSCDMA:
+            case RILConstants.NETWORK_MODE_LTE_TDSCDMA_WCDMA:
+            case RILConstants.NETWORK_MODE_LTE_TDSCDMA_CDMA_EVDO_GSM_WCDMA:
+            case RILConstants.NETWORK_MODE_LTE_CDMA_EVDO_GSM_WCDMA:
+                if (isSupportTdsCdma) {
+                    r = "network_lte";
+                } else {
+                    if (phoneType == RILConstants.CDMA_PHONE || isGlobalCdma || isWorldMode) {
+                        r = "network_global";
+                    } else {
+                        r = (show4GForLTE)
+                                ? "network_4G" : "network_lte";
+                    }
+                }
+                break;
+            default:
+                Log.w(TAG, "unknown phone mode: " + networkMode);
+        }
+
+        if (r != null) {
+            // grab the phone resources
+            final Resources phoneResources = getPhoneResources(context);
+            if (phoneResources != null) {
+                int id = phoneResources.getIdentifier(r, "string", "com.android.phone");
+                if (id > 0) {
+                    return phoneResources.getString(id);
+                } else {
+                    Log.w(TAG, "couldn't find resource id with name: " + r);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean isSupportTdscdma(Context context, int subId) {
+        final Resources phoneResources = getPhoneResources(context);
+        if (phoneResources != null) {
+            int id = phoneResources.getIdentifier("config_support_tdscdma",
+                    "bool", "com.android.phone");
+            if (phoneResources.getBoolean(id)) {
+                return true;
+            }
+
+            final String operatorNumeric = TelephonyManager.from(context)
+                    .getSimOperatorNumericForSubscription(subId);
+
+            int tdcdmaArrId = phoneResources.getIdentifier("config_support_tdscdma_roaming_on_networks",
+                    "string-array", "com.android.phone");
+
+            if (tdcdmaArrId > 0) {
+                String[] numericArray = phoneResources.getStringArray(tdcdmaArrId);
+                if (numericArray.length == 0 || operatorNumeric == null) {
+                    return false;
+                }
+                for (String numeric : numericArray) {
+                    if (operatorNumeric.equals(numeric)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean show4GForLTE(Context context) {
+        try {
+            Context con = context.createPackageContext("com.android.systemui", 0);
+            int id = con.getResources().getIdentifier("config_show4GForLTE",
+                    "bool", "com.android.systemui");
+            return con.getResources().getBoolean(id);
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
+    }
+
+    private static boolean isGlobalCDMA(Context context, int subId, boolean isLteOnCdma) {
+        final CarrierConfigManager carrierConfigMan = (CarrierConfigManager)
+                context.getSystemService(Context.CARRIER_CONFIG_SERVICE);
+        final PersistableBundle carrierConfig = carrierConfigMan.getConfigForSubId(subId);
+        return isLteOnCdma
+                && carrierConfig.getBoolean(CarrierConfigManager.KEY_SHOW_CDMA_CHOICES_BOOL);
+    }
+
+    private static boolean isLteOnCdma(Context context, int subId) {
+        return TelephonyManager.from(context).getLteOnCdmaMode(subId)
+                == PhoneConstants.LTE_ON_CDMA_TRUE;
+    }
+
+    private static boolean isWorldMode(Context context) {
+        boolean worldModeOn = false;
+        final TelephonyManager tm = (TelephonyManager)
+                context.getSystemService(Context.TELEPHONY_SERVICE);
+
+        Resources phoneResources = getPhoneResources(context);
+        if (phoneResources != null) {
+            int id = phoneResources.getIdentifier("config_world_mode",
+                    "string", "com.android.phone");
+
+            if (id > 0) {
+                final String configString = phoneResources.getString(id);
+
+                if (!TextUtils.isEmpty(configString)) {
+                    String[] configArray = configString.split(";");
+                    // Check if we have World mode configuration set to True only or config is set to True
+                    // and SIM GID value is also set and matches to the current SIM GID.
+                    if (configArray != null &&
+                            ((configArray.length == 1 && configArray[0].equalsIgnoreCase("true")) ||
+                                    (configArray.length == 2 && !TextUtils.isEmpty(configArray[1]) &&
+                                            tm != null && configArray[1].equalsIgnoreCase(tm.getGroupIdLevel1())))) {
+                        worldModeOn = true;
+                    }
+                }
+            } else {
+                Log.w(TAG, "couldn't find resource of config_world_mode");
+            }
+        }
+
+        return worldModeOn;
+    }
+
+    private static Resources getPhoneResources(Context context) {
+        try {
+            final Context packageContext = context.createPackageContext("com.android.phone", 0);
+            return packageContext.getResources();
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        Log.w(TAG, "couldn't locate resources for com.android.phone!");
+        return null;
+    }
+}


### PR DESCRIPTION
When configuring profiles and selecting a network mode override, ask
Telephony to provide the UI for showing the proper network modes. After
the user has selected it, we receive the result, and save it in the
profile.

Ref: CYNGNOS-1463

Change-Id: I866ed1bc1c915ae00804b07dbbafa86e679a5fa7
Signed-off-by: Roman Birg <roman@cyngn.com>