### PR TITLE
Settings: add marquee to Device administrators screen

### DIFF
--- a/res/layout/device_admin_item.xml
+++ b/res/layout/device_admin_item.xml
@@ -55,6 +55,8 @@
             android:singleLine="true"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:ellipsize="marquee"
+            android:marqueeRepeatLimit="marquee_forever"
+            android:scrollHorizontally="true"
             android:layout_alignParentTop="true"
             android:fadingEdge="horizontal" />
 

--- a/src/com/android/settings/DeviceAdminSettings.java
+++ b/src/com/android/settings/DeviceAdminSettings.java
@@ -337,6 +337,7 @@ public class DeviceAdminSettings extends ListFragment {
             }
             vh.checkbox.setEnabled(enabled);
             vh.name.setEnabled(enabled);
+            vh.name.setSelected(true);
             vh.description.setEnabled(enabled);
             vh.icon.setEnabled(enabled);
         }


### PR DESCRIPTION
Noticed while doing CTS testing that it was really hard to pick the
correct receivers to enable when you cannot see their full names.

Change-Id: I8f14d04f1037158c94d5501c115b5100456d7619
Signed-off-by: Roman Birg <roman@cyngn.com>
(cherry picked from commit 83b4a9951b8aadfba35d8f12d075231e7cb36385)