### PR TITLE
Settings: fix incorrect default sim/sms/data selection logic

### DIFF
--- a/src/com/android/settings/sim/SimDialogActivity.java
+++ b/src/com/android/settings/sim/SimDialogActivity.java
@@ -295,6 +295,7 @@ public class SimDialogActivity extends Activity {
                 }
             }
         } else {
+            currentIndex = -1;
             final int defaultDataSubId = SubscriptionManager.getDefaultDataSubId();
             for (int i = 0; i < selectableSubInfoLength; ++i) {
                 final SubscriptionInfo sir = subInfoList.get(i);


### PR DESCRIPTION
change id I8ba32f3b203751e79697c7dcbc2cfcf1c6ae4ad0 broke this and
assumed all needed a default index of 0; set it to -1 only for the data
selection.

Ticket: CYNGNOS-2388, CYNGNOS-2212

Change-Id: Ic81d1151aa71017e261107f1d67785cc50f2bd7f
Signed-off-by: Roman Birg <roman@cyngn.com>