### PR TITLE
Add config to hide/show weather menu

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -120,4 +120,6 @@
     <!-- When true Live lock screen settings will be positioned at the top -->
     <bool name="config_showLiveLockScreenSettingsFirst">false</bool>
 
+    <!-- When true, weather options will be displayed in settings dashboard -->
+    <bool name="config_showWeatherMenu">true</bool>
 </resources>

--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -1333,8 +1333,11 @@ public class SettingsActivity extends Activity
                         removeTile = true;
                     }
                 } else if (id == R.id.weather_settings) {
+                    final boolean showWeatherMenu = getResources()
+                            .getBoolean(R.bool.config_showWeatherMenu);
+
                     if (!getPackageManager().hasSystemFeature(
-                            CMContextConstants.Features.WEATHER_SERVICES)) {
+                            CMContextConstants.Features.WEATHER_SERVICES) || !showWeatherMenu) {
                         removeTile = true;
                     }
                 }


### PR DESCRIPTION
This config controls whether the weather menu
should be displayed in settings

Change-Id: I89502d22cb56496825f497e6b19fce3d8e0a7a3c
TICKET: CYNGNOS-2796