### PR TITLE
Disable cellular networks settings menu if airplane mode is enabled

### DIFF
--- a/src/com/android/settings/Utils.java
+++ b/src/com/android/settings/Utils.java
@@ -73,6 +73,7 @@ import android.provider.ContactsContract.Contacts;
 import android.provider.ContactsContract.Data;
 import android.provider.ContactsContract.Profile;
 import android.provider.ContactsContract.RawContacts;
+import android.provider.Settings;
 import android.service.persistentdata.PersistentDataBlockManager;
 import android.telephony.ServiceState;
 import android.telephony.TelephonyManager;
@@ -1448,5 +1449,10 @@ public final class Utils {
             return res.getString(R.string.join_many_items_last, allButLast,
                     items.get(count - 1));
         }
+    }
+
+    public static boolean isAirplaneModeEnabled(Context context) {
+        return Settings.Global.getInt(context.getContentResolver(),
+                Settings.Global.AIRPLANE_MODE_ON, 0) != 0;
     }
 }

--- a/src/com/android/settings/dashboard/DashboardSummary.java
+++ b/src/com/android/settings/dashboard/DashboardSummary.java
@@ -43,6 +43,7 @@ import com.android.settings.HelpUtils;
 import com.android.settings.InstrumentedFragment;
 import com.android.settings.R;
 import com.android.settings.SettingsActivity;
+import com.android.settings.Utils;
 import com.android.settings.widget.SwitchBar;
 
 import java.util.List;
@@ -105,6 +106,10 @@ public class DashboardSummary extends InstrumentedFragment {
         filter.addAction(Intent.ACTION_PACKAGE_REPLACED);
         filter.addDataScheme("package");
         getActivity().registerReceiver(mHomePackageReceiver, filter);
+
+        final IntentFilter airplaneModeFilter
+                = new IntentFilter(Intent.ACTION_AIRPLANE_MODE_CHANGED);
+        getActivity().registerReceiver(mHomePackageReceiver, airplaneModeFilter);
     }
 
     @Override
@@ -165,6 +170,9 @@ public class DashboardSummary extends InstrumentedFragment {
 
                 tileView.setTile(tile);
 
+                if (tile.id == R.id.mobile_networks) {
+                    tileView.setEnabledTile(!Utils.isAirplaneModeEnabled(context));
+                }
                 categoryContent.addView(tileView);
             }
 

--- a/src/com/android/settings/dashboard/DashboardTileView.java
+++ b/src/com/android/settings/dashboard/DashboardTileView.java
@@ -150,5 +150,13 @@ public class DashboardTileView extends FrameLayout implements View.OnClickListen
         return mSwitch;
     }
 
-
+    public void setEnabledTile(boolean enabled) {
+        mImageView.setAlpha(enabled ? 1f : Utils.DISABLED_ALPHA);
+        mTitleTextView.setEnabled(enabled);
+        mStatusTextView.setEnabled(enabled);
+        mSwitch.setEnabled(enabled);
+        mSwitch.setClickable(enabled);
+        setFocusable(enabled);
+        setEnabled(enabled);
+    }
 }


### PR DESCRIPTION
Cellular networks settings menu will be disabled
if user enables airplane mode

Change-Id: I83d78754918d50c02e19121ffcfb673bb1dc5797
TICKET: CYNGNOS-2697