### PR TITLE
Settings: move high touch sensitivity setting to Display

### DIFF
--- a/res/xml/display.xml
+++ b/res/xml/display.xml
@@ -80,6 +80,12 @@
                 android:defaultValue="true" />
 
         <SwitchPreference
+                android:key="high_touch_sensitivity"
+                android:title="@string/high_touch_sensitivity_title"
+                android:summary="@string/high_touch_sensitivity_summary"
+                android:defaultValue="false" />
+
+        <SwitchPreference
                 android:key="camera_gesture"
                 android:title="@string/camera_gesture_title"
                 android:summary="@string/camera_gesture_desc"

--- a/res/xml/language_settings.xml
+++ b/res/xml/language_settings.xml
@@ -133,12 +133,6 @@
                 android:persistent="false" />
 
         <SwitchPreference
-                android:key="high_touch_sensitivity"
-                android:title="@string/high_touch_sensitivity_title"
-                android:summary="@string/high_touch_sensitivity_summary"
-                android:defaultValue="false" />
-
-        <SwitchPreference
                 android:key="touchscreen_hovering"
                 android:title="@string/touchscreen_hovering_title"
                 android:summary="@string/touchscreen_hovering_summary"

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -20,6 +20,7 @@ import com.android.internal.logging.MetricsLogger;
 
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.preference.CheckBoxPreference;
 
 import android.os.UserHandle;
@@ -83,6 +84,7 @@ import java.util.List;
 import com.android.settings.Utils;
 import com.android.settings.cyanogenmod.DisplayRotation;
 
+import cyanogenmod.hardware.CMHardwareManager;
 import cyanogenmod.hardware.LiveDisplayManager;
 import cyanogenmod.providers.CMSettings;
 
@@ -113,6 +115,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private static final String KEY_NOTIFICATION_LIGHT = "notification_light";
     private static final String KEY_BATTERY_LIGHT = "battery_light";
     private static final String KEY_LIVEDISPLAY = "live_display";
+    private static final String KEY_HIGH_TOUCH_SENSITIVITY = "high_touch_sensitivity";
 
     private static final int DLG_GLOBAL_CHANGE_WARNING = 1;
 
@@ -130,9 +133,12 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private SwitchPreference mLiftToWakePreference;
     private SwitchPreference mDozePreference;
     private SwitchPreference mTapToWakePreference;
+    private SwitchPreference mHighTouchSensitivity;
     private SwitchPreference mProximityCheckOnWakePreference;
     private SwitchPreference mAutoBrightnessPreference;
     private SwitchPreference mWakeWhenPluggedOrUnplugged;
+
+    private CMHardwareManager mHardware;
 
     private ContentObserver mAccelerometerRotationObserver =
             new ContentObserver(new Handler()) {
@@ -163,6 +169,8 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
         final Activity activity = getActivity();
         final ContentResolver resolver = activity.getContentResolver();
         addPreferencesFromResource(R.xml.display);
+
+        mHardware = CMHardwareManager.getInstance(activity);
 
         PreferenceCategory displayPrefs = (PreferenceCategory)
                 findPreference(KEY_CATEGORY_DISPLAY);
@@ -292,6 +300,16 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             if (displayPrefs != null && mTapToWakePreference != null) {
                 displayPrefs.removePreference(mTapToWakePreference);
             }
+        }
+
+        mHighTouchSensitivity = (SwitchPreference) findPreference(KEY_HIGH_TOUCH_SENSITIVITY);
+        if (!mHardware.isSupported(
+                CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY)) {
+            displayPrefs.removePreference(mHighTouchSensitivity);
+            mHighTouchSensitivity = null;
+        } else {
+            mHighTouchSensitivity.setChecked(
+                    mHardware.get(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY));
         }
 
         mProximityCheckOnWakePreference = (SwitchPreference) findPreference(KEY_PROXIMITY_WAKE);
@@ -677,6 +695,12 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
         } else if (preference == mAccelerometer) {
             RotationPolicy.setRotationLockForAccessibility(getActivity(),
                     !mAccelerometer.isChecked());
+        } else if (preference == mHighTouchSensitivity) {
+            boolean mHighTouchSensitivityEnable = mHighTouchSensitivity.isChecked();
+            CMSettings.System.putInt(getActivity().getContentResolver(),
+                    CMSettings.System.HIGH_TOUCH_SENSITIVITY_ENABLE,
+                    mHighTouchSensitivityEnable ? 1 : 0);
+            return true;
         }
 
         return super.onPreferenceTreeClick(preferenceScreen, preference);
@@ -796,6 +820,8 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
 
                 @Override
                 public List<String> getNonIndexableKeys(Context context) {
+                    final CMHardwareManager hardware = CMHardwareManager.getInstance(context);
+
                     ArrayList<String> result = new ArrayList<String>();
                     if (!context.getResources().getBoolean(
                             com.android.internal.R.bool.config_dreamsSupported)) {
@@ -828,7 +854,23 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
                     if (!isCameraGestureAvailable(context.getResources())) {
                         result.add(KEY_CAMERA_GESTURE);
                     }
+                    if (hardware.isSupported(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY)) {
+                        result.add(KEY_HIGH_TOUCH_SENSITIVITY);
+                    }
                     return result;
                 }
             };
+
+    public static void restore(Context context) {
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        final CMHardwareManager hardware = CMHardwareManager.getInstance(context);
+        if (hardware.isSupported(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY)) {
+            final boolean enabled = prefs.getBoolean(KEY_HIGH_TOUCH_SENSITIVITY,
+                    hardware.get(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY));
+            CMSettings.System.putInt(context.getContentResolver(),
+                    CMSettings.System.HIGH_TOUCH_SENSITIVITY_ENABLE,
+                    enabled ? 1 : 0);
+        }
+    }
+
 }

--- a/src/com/android/settings/cyanogenmod/BootReceiver.java
+++ b/src/com/android/settings/cyanogenmod/BootReceiver.java
@@ -23,6 +23,7 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
 import com.android.settings.ButtonSettings;
+import com.android.settings.DisplaySettings;
 import com.android.settings.R;
 import com.android.settings.Utils;
 import com.android.settings.contributors.ContributorsCloudFragment;
@@ -43,6 +44,7 @@ public class BootReceiver extends BroadcastReceiver {
             ButtonSettings.restoreKeyDisabler(ctx);
             VibratorIntensity.restore(ctx);
             InputMethodAndLanguageSettings.restore(ctx);
+            DisplaySettings.restore(ctx);
             setRestoredTunable(ctx);
         }
 

--- a/src/com/android/settings/inputmethod/InputMethodAndLanguageSettings.java
+++ b/src/com/android/settings/inputmethod/InputMethodAndLanguageSettings.java
@@ -93,7 +93,6 @@ public class InputMethodAndLanguageSettings extends SettingsPreferenceFragment
     private static final String KEY_USER_DICTIONARY_SETTINGS = "key_user_dictionary_settings";
     private static final String KEY_POINTER_SETTINGS_CATEGORY = "pointer_settings_category";
     private static final String KEY_PREVIOUSLY_ENABLED_SUBTYPES = "previously_enabled_subtypes";
-    private static final String KEY_HIGH_TOUCH_SENSITIVITY = "high_touch_sensitivity";
     private static final String KEY_TOUCHSCREEN_HOVERING = "touchscreen_hovering";
     private static final String KEY_TRACKPAD_SETTINGS = "gesture_pad_settings";
     private static final String KEY_STYLUS_GESTURES = "stylus_gestures";
@@ -115,7 +114,6 @@ public class InputMethodAndLanguageSettings extends SettingsPreferenceFragment
     private int mDefaultInputMethodSelectorVisibility = 0;
     private ListPreference mShowInputMethodSelectorPref;
     private SwitchPreference mStylusIconEnabled;
-    private SwitchPreference mHighTouchSensitivity;
     private SwitchPreference mTouchscreenHovering;
     private PreferenceCategory mKeyboardSettingsCategory;
     private PreferenceCategory mHardKeyboardCategory;
@@ -203,7 +201,6 @@ public class InputMethodAndLanguageSettings extends SettingsPreferenceFragment
 
         mStylusGestures = (PreferenceScreen) findPreference(KEY_STYLUS_GESTURES);
         mStylusIconEnabled = (SwitchPreference) findPreference(KEY_STYLUS_ICON_ENABLED);
-        mHighTouchSensitivity = (SwitchPreference) findPreference(KEY_HIGH_TOUCH_SENSITIVITY);
 
         mTouchscreenHovering = (SwitchPreference) findPreference(KEY_TOUCHSCREEN_HOVERING);
 
@@ -211,15 +208,6 @@ public class InputMethodAndLanguageSettings extends SettingsPreferenceFragment
             if (!getResources().getBoolean(com.android.internal.R.bool.config_stylusGestures)) {
                 pointerSettingsCategory.removePreference(mStylusGestures);
                 pointerSettingsCategory.removePreference(mStylusIconEnabled);
-            }
-
-            if (!mHardware.isSupported(
-                    CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY)) {
-                pointerSettingsCategory.removePreference(mHighTouchSensitivity);
-                mHighTouchSensitivity = null;
-            } else {
-                mHighTouchSensitivity.setChecked(
-                        mHardware.get(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY));
             }
 
             if (!mHardware.isSupported(CMHardwareManager.FEATURE_TOUCH_HOVERING)) {
@@ -433,12 +421,6 @@ public class InputMethodAndLanguageSettings extends SettingsPreferenceFragment
         if (preference == mStylusIconEnabled) {
             Settings.System.putInt(getActivity().getContentResolver(),
                     Settings.System.STYLUS_ICON_ENABLED, mStylusIconEnabled.isChecked() ? 1 : 0);
-        } else if (preference == mHighTouchSensitivity) {
-            boolean mHighTouchSensitivityEnable = mHighTouchSensitivity.isChecked();
-            CMSettings.System.putInt(getActivity().getContentResolver(),
-                    CMSettings.System.HIGH_TOUCH_SENSITIVITY_ENABLE,
-                    mHighTouchSensitivityEnable ? 1 : 0);
-            return true;
         } else if (preference == mTouchscreenHovering) {
             boolean touchHoveringEnable = mTouchscreenHovering.isChecked();
             CMSettings.Secure.putInt(getActivity().getContentResolver(),
@@ -785,13 +767,6 @@ public class InputMethodAndLanguageSettings extends SettingsPreferenceFragment
     public static void restore(Context context) {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         final CMHardwareManager hardware = CMHardwareManager.getInstance(context);
-        if (hardware.isSupported(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY)) {
-            final boolean enabled = prefs.getBoolean(KEY_HIGH_TOUCH_SENSITIVITY,
-                    hardware.get(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY));
-            CMSettings.System.putInt(context.getContentResolver(),
-                    CMSettings.System.HIGH_TOUCH_SENSITIVITY_ENABLE,
-                    enabled ? 1 : 0);
-        }
         if (hardware.isSupported(CMHardwareManager.FEATURE_TOUCH_HOVERING)) {
             final boolean enabled = prefs.getBoolean(KEY_TOUCHSCREEN_HOVERING,
                     hardware.get(CMHardwareManager.FEATURE_TOUCH_HOVERING));


### PR DESCRIPTION
For devices that support this feature, it makes sense to place this
under display settings as most people wouldn't look under language.

Ticket: CYNGNOS-3250
Change-Id: Ib99f5e8c5f0f2bdae7b5b5f788a364a1d63aa146
Signed-off-by: Roman Birg <roman@cyngn.com>