### PR TITLE
Add new importance level for blocking lock screen notifications (2/2)

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -305,6 +305,9 @@
     <string name="ime_switcher_notify">Selector notification</string>
     <string name="ime_switcher_notify_summary">Display input method selector notification</string>
 
+    <!-- [CHAR LIMIT=100] Notification Importance slider: very low importance level description -->
+    <string name="notification_importance_very_low">No full screen interruption, peeking, sound, or vibration. Show at the bottom of the notification list. Hide from lock screen.</string>
+
     <!-- Stylus Icon -->
     <string name="stylus_icon_enabled_title">Show icon when using stylus</string>
     <string name="stylus_icon_enabled_summary">Show the pointer icon when hovering or drawing with the stylus</string>

--- a/src/com/android/settings/notification/ImportanceSeekBarPreference.java
+++ b/src/com/android/settings/notification/ImportanceSeekBarPreference.java
@@ -172,6 +172,8 @@ public class ImportanceSeekBarPreference extends SeekBarPreference implements
                 return getContext().getString(R.string.notification_importance_blocked);
             case NotificationListenerService.Ranking.IMPORTANCE_MIN:
                 return getContext().getString(R.string.notification_importance_min);
+            case NotificationListenerService.Ranking.IMPORTANCE_VERY_LOW:
+                return getContext().getString(R.string.notification_importance_very_low);
             case NotificationListenerService.Ranking.IMPORTANCE_LOW:
                 return getContext().getString(R.string.notification_importance_low);
             case NotificationListenerService.Ranking.IMPORTANCE_DEFAULT:


### PR DESCRIPTION
One feature that is still missing in the handling of notifications in
N is the possibility to block them app-wise for relevance/importance
reasons rather than for privacy reasons – i.e. also on the insecure
lock screen.

This patch plugs the hole by introducing a new importance level "very
low" between "min" and "low" in the power notification controls that
allows notifications on the status bar, but not on the lock screen.

It brings back most of the functionality of
Ib166db1b1673aeaea132c8eeb16c650d2f254a82 excluding the ability of
blocking only ongoing (persistent) notifications.

Change-Id: I01651c95a3fda68de6a2dd9e1acec5c9ea543f84
Signed-off-by: Marc K <morckx@gmail.com>