### PR TITLE
settings: Move Emergency broadcasts to Wireless & networks

### DIFF
--- a/res/xml/sound_settings.xml
+++ b/res/xml/sound_settings.xml
@@ -91,16 +91,6 @@
                 android:persistent="false"
                 android:ringtoneType="alarm" />
 
-        <com.android.settingslib.RestrictedPreference
-                android:key="cell_broadcast_settings"
-                android:title="@string/cell_broadcast_settings"
-                settings:useAdminDisabledSummary="true">
-                <!--intent
-                        android:action="android.intent.action.MAIN"
-                        android:targetPackage="com.android.cellbroadcastreceiver"
-                        android:targetClass="com.android.cellbroadcastreceiver.CellBroadcastSettings" /-->
-        </com.android.settingslib.RestrictedPreference>
-
         <!-- Other sounds -->
         <Preference
                 android:key="other_sounds"

--- a/res/xml/wireless_settings.xml
+++ b/res/xml/wireless_settings.xml
@@ -64,6 +64,16 @@
         settings:useAdminDisabledSummary="true" />
 
     <com.android.settingslib.RestrictedPreference
+            android:key="cell_broadcast_settings"
+            android:title="@string/cell_broadcast_settings"
+            settings:useAdminDisabledSummary="true">
+            <!--intent
+                    android:action="android.intent.action.MAIN"
+                    android:targetPackage="com.android.cellbroadcastreceiver"
+                    android:targetClass="com.android.cellbroadcastreceiver.CellBroadcastSettings" /-->
+    </com.android.settingslib.RestrictedPreference>
+
+    <com.android.settingslib.RestrictedPreference
         android:key="wimax_settings"
         android:title="@string/wimax_settings"
         settings:userRestriction="no_config_mobile_networks"

--- a/src/com/android/settings/notification/SoundSettings.java
+++ b/src/com/android/settings/notification/SoundSettings.java
@@ -86,7 +86,6 @@ public class SoundSettings extends SettingsPreferenceFragment implements Indexab
     private static final String KEY_WIFI_DISPLAY = "wifi_display";
     private static final String KEY_INCREASING_RING_VOLUME = "increasing_ring_volume";
     private static final String KEY_ZEN_MODE = "zen_mode";
-    private static final String KEY_CELL_BROADCAST_SETTINGS = "cell_broadcast_settings";
 
     private static final String SELECTED_PREFERENCE_KEY = "selected_preference";
     private static final int REQUEST_CODE = 200;
@@ -133,7 +132,6 @@ public class SoundSettings extends SettingsPreferenceFragment implements Indexab
     private int mRingerMode = -1;
 
     private PackageManager mPm;
-    private UserManager mUserManager;
     private RingtonePreference mRequestPreference;
 
     @Override
@@ -146,7 +144,6 @@ public class SoundSettings extends SettingsPreferenceFragment implements Indexab
         super.onCreate(savedInstanceState);
         mContext = getActivity();
         mPm = getPackageManager();
-        mUserManager = UserManager.get(getContext());
         mVoiceCapable = Utils.isVoiceCapable(mContext);
 
         mAudioManager = (AudioManager) mContext.getSystemService(Context.AUDIO_SERVICE);
@@ -173,24 +170,6 @@ public class SoundSettings extends SettingsPreferenceFragment implements Indexab
             removePreference(KEY_RING_VOLUME);
         }
 
-        // Enable link to CMAS app settings depending on the value in config.xml.
-        boolean isCellBroadcastAppLinkEnabled = this.getResources().getBoolean(
-                com.android.internal.R.bool.config_cellBroadcastAppLinks);
-        try {
-            if (isCellBroadcastAppLinkEnabled) {
-                if (mPm.getApplicationEnabledSetting("com.android.cellbroadcastreceiver")
-                        == PackageManager.COMPONENT_ENABLED_STATE_DISABLED) {
-                    isCellBroadcastAppLinkEnabled = false;  // CMAS app disabled
-                }
-            }
-        } catch (IllegalArgumentException ignored) {
-            isCellBroadcastAppLinkEnabled = false;  // CMAS app not installed
-        }
-        if (!mUserManager.isAdminUser() || !isCellBroadcastAppLinkEnabled ||
-                RestrictedLockUtils.hasBaseUserRestriction(mContext,
-                        UserManager.DISALLOW_CONFIG_CELL_BROADCASTS, UserHandle.myUserId())) {
-            removePreference(KEY_CELL_BROADCAST_SETTINGS);
-        }
         initRingtones();
         initVibrateWhenRinging();
         initIncreasingRing();
@@ -233,12 +212,6 @@ public class SoundSettings extends SettingsPreferenceFragment implements Indexab
                 ((RestrictedPreference) pref).setDisabledByAdmin(admin);
             }
         }
-        RestrictedPreference broadcastSettingsPref = (RestrictedPreference) findPreference(
-                KEY_CELL_BROADCAST_SETTINGS);
-        if (broadcastSettingsPref != null) {
-            broadcastSettingsPref.checkRestrictionAndSetDisabled(
-                    UserManager.DISALLOW_CONFIG_CELL_BROADCASTS);
-        }
     }
 
     @Override
@@ -269,20 +242,6 @@ public class SoundSettings extends SettingsPreferenceFragment implements Indexab
             mRequestPreference = (RingtonePreference) preference;
             mRequestPreference.onPrepareRingtonePickerIntent(mRequestPreference.getIntent());
             startActivityForResult(preference.getIntent(), REQUEST_CODE);
-            return true;
-        } else if (preference == findPreference(KEY_CELL_BROADCAST_SETTINGS)) {
-            final Intent intent = new Intent(Intent.ACTION_MAIN);
-            intent.setComponent(new ComponentName(
-                 "com.android.cellbroadcastreceiver",
-                 "com.android.cellbroadcastreceiver.CellBroadcastSettings"));
-
-            if (mContext.getPackageManager()
-                        .queryIntentActivities(intent, 0).isEmpty())  {
-                Log.d(TAG, "Activity com.android.cellbroadcastreceiver" +
-                                ".CellBroadcastSettings does not exist");
-                return false;
-            }
-            startActivity(intent);
             return true;
         }
 
@@ -705,26 +664,6 @@ public class SoundSettings extends SettingsPreferenceFragment implements Indexab
                 rt.add(KEY_PHONE_RINGTONE);
                 rt.add(KEY_WIFI_DISPLAY);
                 rt.add(KEY_VIBRATE_WHEN_RINGING);
-            }
-
-            final PackageManager pm = context.getPackageManager();
-            final UserManager um = (UserManager) context.getSystemService(Context.USER_SERVICE);
-
-            // Enable link to CMAS app settings depending on the value in config.xml.
-            boolean isCellBroadcastAppLinkEnabled = context.getResources().getBoolean(
-                    com.android.internal.R.bool.config_cellBroadcastAppLinks);
-            try {
-                if (isCellBroadcastAppLinkEnabled) {
-                    if (pm.getApplicationEnabledSetting("com.android.cellbroadcastreceiver")
-                            == PackageManager.COMPONENT_ENABLED_STATE_DISABLED) {
-                        isCellBroadcastAppLinkEnabled = false;  // CMAS app disabled
-                    }
-                }
-            } catch (IllegalArgumentException ignored) {
-                isCellBroadcastAppLinkEnabled = false;  // CMAS app not installed
-            }
-            if (!um.isAdminUser() || !isCellBroadcastAppLinkEnabled) {
-                rt.add(KEY_CELL_BROADCAST_SETTINGS);
             }
 
             return rt;


### PR DESCRIPTION
 * Having the CellBroadcastReceiver access inside 'Sounds'
    does not make much sense for most users, therefore
    move it to the 'More' > Wireless & networks

Change-Id: Ife1a04201d79b76d061653472d87f5a96e76d450