### PR TITLE
lockscreen: Forward port option to pass swipe-up-to-unlock

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -248,6 +248,12 @@
     <string name="lockpattern_settings_enable_error_path_title">Show pattern error</string>
     <!-- Whether the dots will be drawn when using the lockscreen pattern -->
     <string name="lockpattern_settings_enable_dots_title">Show pattern dots</string>
+    <!-- Whether the keyguard will directly show the password entry -->
+    <string name="lock_directly_show_password">Directly show password entry</string>
+    <!-- Whether the keyguard will directly show the pattern view -->
+    <string name="lock_directly_show_pattern">Directly show pattern view</string>
+    <!-- Whether the keyguard will directly show the PIN entry -->
+    <string name="lock_directly_show_pin">Directly show PIN entry</string>
 
     <!-- Lock screen vibrate settings -->
     <string name="lockscreen_vibrate_enabled_title">Vibrate</string>

--- a/res/xml/security_settings_password_sub.xml
+++ b/res/xml/security_settings_password_sub.xml
@@ -31,6 +31,11 @@
                 android:key="power_button_instantly_locks"
                 android:title="@string/lockpattern_settings_enable_power_button_instantly_locks"/>
 
+        <SwitchPreference
+                android:key="directly_show_lock"
+                android:title="@string/lock_directly_show_password"
+                android:persistent="false" />
+
         <com.android.settings.SingleLineSummaryPreference
                 android:key="owner_info_settings"
                 android:title="@string/owner_info_settings_title"

--- a/res/xml/security_settings_pattern_sub.xml
+++ b/res/xml/security_settings_pattern_sub.xml
@@ -35,6 +35,11 @@
                 android:key="power_button_instantly_locks"
                 android:title="@string/lockpattern_settings_enable_power_button_instantly_locks"/>
 
+        <SwitchPreference
+                android:key="directly_show_lock"
+                android:title="@string/lock_directly_show_pattern"
+                android:persistent="false" />
+
         <com.android.settings.SingleLineSummaryPreference
                 android:key="owner_info_settings"
                 android:title="@string/owner_info_settings_title"

--- a/res/xml/security_settings_pin_sub.xml
+++ b/res/xml/security_settings_pin_sub.xml
@@ -31,6 +31,11 @@
                 android:key="power_button_instantly_locks"
                 android:title="@string/lockpattern_settings_enable_power_button_instantly_locks"/>
 
+        <SwitchPreference
+                android:key="directly_show_lock"
+                android:title="@string/lock_directly_show_pin"
+                android:persistent="false" />
+
         <com.android.settings.SingleLineSummaryPreference
                 android:key="owner_info_settings"
                 android:title="@string/owner_info_settings_title"

--- a/src/com/android/settings/ChooseLockSettingsHelper.java
+++ b/src/com/android/settings/ChooseLockSettingsHelper.java
@@ -27,6 +27,8 @@ import android.os.UserManager;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.widget.LockPatternUtils;
 
+import org.cyanogenmod.internal.util.CmLockPatternUtils;
+
 public final class ChooseLockSettingsHelper {
 
     static final String EXTRA_KEY_TYPE = "type";
@@ -40,12 +42,14 @@ public final class ChooseLockSettingsHelper {
 
 
     @VisibleForTesting LockPatternUtils mLockPatternUtils;
+    private CmLockPatternUtils mCmLockPatternUtils;
     private Activity mActivity;
     private Fragment mFragment;
 
     public ChooseLockSettingsHelper(Activity activity) {
         mActivity = activity;
         mLockPatternUtils = new LockPatternUtils(activity);
+        mCmLockPatternUtils = new CmLockPatternUtils(activity);
     }
 
     public ChooseLockSettingsHelper(Activity activity, Fragment fragment) {
@@ -55,6 +59,10 @@ public final class ChooseLockSettingsHelper {
 
     public LockPatternUtils utils() {
         return mLockPatternUtils;
+    }
+
+    public CmLockPatternUtils cmUtils() {
+        return mCmLockPatternUtils;
     }
 
     /**

--- a/src/com/android/settings/SecuritySettings.java
+++ b/src/com/android/settings/SecuritySettings.java
@@ -64,6 +64,10 @@ import com.android.settingslib.RestrictedLockUtils;
 import com.android.settingslib.RestrictedPreference;
 import com.android.settingslib.RestrictedSwitchPreference;
 
+import cyanogenmod.providers.CMSettings;
+
+import org.cyanogenmod.internal.util.CmLockPatternUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -1013,17 +1017,20 @@ public class SecuritySettings extends SettingsPreferenceFragment
         private static final String KEY_LOCK_AFTER_TIMEOUT = "lock_after_timeout";
         private static final String KEY_OWNER_INFO_SETTINGS = "owner_info_settings";
         private static final String KEY_POWER_INSTANTLY_LOCKS = "power_button_instantly_locks";
+        private static final String KEY_DIRECTLY_SHOW_LOCK = "directly_show_lock";
 
         // These switch preferences need special handling since they're not all stored in Settings.
         private static final String SWITCH_PREFERENCE_KEYS[] = { KEY_LOCK_AFTER_TIMEOUT,
-                KEY_VISIBLE_PATTERN, KEY_POWER_INSTANTLY_LOCKS };
+                KEY_VISIBLE_PATTERN, KEY_POWER_INSTANTLY_LOCKS, KEY_DIRECTLY_SHOW_LOCK };
 
         private TimeoutListPreference mLockAfter;
         private SwitchPreference mVisiblePattern;
         private SwitchPreference mPowerButtonInstantlyLocks;
+        private SwitchPreference mDirectlyShowLock;
         private RestrictedPreference mOwnerInfoPref;
 
         private LockPatternUtils mLockPatternUtils;
+        private ChooseLockSettingsHelper mChooseLockSettingsHelper;
         private DevicePolicyManager mDPM;
 
         @Override
@@ -1035,6 +1042,7 @@ public class SecuritySettings extends SettingsPreferenceFragment
         public void onCreate(Bundle icicle) {
             super.onCreate(icicle);
             mLockPatternUtils = new LockPatternUtils(getContext());
+            mChooseLockSettingsHelper = new ChooseLockSettingsHelper(getActivity());
             mDPM = getContext().getSystemService(DevicePolicyManager.class);
             createPreferenceHierarchy();
         }
@@ -1051,6 +1059,11 @@ public class SecuritySettings extends SettingsPreferenceFragment
             }
             if (mPowerButtonInstantlyLocks != null) {
                 mPowerButtonInstantlyLocks.setChecked(mLockPatternUtils.getPowerButtonInstantlyLocks(
+                        MY_USER_ID));
+            }
+            final CmLockPatternUtils cmLockPatternUtils = mChooseLockSettingsHelper.cmUtils();
+            if (mDirectlyShowLock != null) {
+                mDirectlyShowLock.setChecked(cmLockPatternUtils.shouldPassToSecurityView(
                         MY_USER_ID));
             }
 
@@ -1075,6 +1088,9 @@ public class SecuritySettings extends SettingsPreferenceFragment
                     new LockPatternUtils(getContext()),
                     ManagedLockPasswordProvider.get(getContext(), MY_USER_ID));
             addPreferencesFromResource(resid);
+
+            // directly show lock
+            mDirectlyShowLock = (SwitchPreference) findPreference(KEY_DIRECTLY_SHOW_LOCK);
 
             // lock after preference
             mLockAfter = (TimeoutListPreference) findPreference(KEY_LOCK_AFTER_TIMEOUT);
@@ -1221,6 +1237,9 @@ public class SecuritySettings extends SettingsPreferenceFragment
             String key = preference.getKey();
             if (KEY_POWER_INSTANTLY_LOCKS.equals(key)) {
                 mLockPatternUtils.setPowerButtonInstantlyLocks((Boolean) value, MY_USER_ID);
+            } else if (KEY_DIRECTLY_SHOW_LOCK.equals(key)) {
+                final CmLockPatternUtils cmLockPatternUtils = mChooseLockSettingsHelper.cmUtils();
+                cmLockPatternUtils.setPassToSecurityView((Boolean) value, MY_USER_ID);
             } else if (KEY_LOCK_AFTER_TIMEOUT.equals(key)) {
                 int timeout = Integer.parseInt((String) value);
                 try {


### PR DESCRIPTION
 * Adapt settings to Nougat SecuritySubSettings class
 * Interface switches in security_settings_*_sub.xml
 * Additional changes for dependencies
 * Cleanup the names to 'directly_show_lock'
 * Reorder the new preferences

lockscreen: Add option to pass swipe-up-to-unlock (2/3)

* Option appears on PIN,pattern and password methods
* User should press back button to see notifications, clock etc.
* Instantly hides keyguard if Smart Lock has unlocked phone.

CYNGNOS-1873
Change-Id: I31256770869b20842c69edb4a7a57b2bad7b3ea7
Signed-off-by: eray orçunus <erayorcunus@gmail.com>