### PR TITLE
Settings: Set summary for zen priority notif preference

### DIFF
--- a/res/xml/zen_mode_priority_settings.xml
+++ b/res/xml/zen_mode_priority_settings.xml
@@ -56,6 +56,7 @@
     <cyanogenmod.preference.CMSystemSettingDropDownPreference
         android:key="zen_priority_vibration_mode"
         android:title="@string/zen_mode_vibration"
+        android:summary="%s"
         android:entries="@array/zen_vibration_mode_entries"
         android:entryValues="@array/zen_vibration_mode_values"
         android:defaultValue="0" />


### PR DESCRIPTION
Allow the user to see, at a glance, his/her current preference.

Change-Id: I3b4e4f2c799c3afa984628c8e54f38be3856a6c6