### PR TITLE
Always show band 0 (Automatic)

### DIFF
--- a/src/com/android/settings/BandMode.java
+++ b/src/com/android/settings/BandMode.java
@@ -161,6 +161,11 @@ public class BandMode extends Activity {
                 return;
             }
 
+            // Always show Band 0, ie Automatic
+            item = new BandListItem(0);
+            mBandListAdapter.add(item);
+            if (DBG) log("Add " + item.toString());
+
             for (int i=0; i<bands.length; i++) {
                 item = new BandListItem(bands[i]);
                 mBandListAdapter.add(item);


### PR DESCRIPTION
None of the phones I tested ever displayed Automatic band selection as a
choice, probably because no baseband is going to report it supports
mythical band 0. Make sure it is always displayed.

nuclearmistake's notes:
Without this, a wipe is required to set band mode to automatic.
If someone in singapore set the their phone to US mode, and was only
offered "US" and "Europe" band modes, they would have to WIPE to
return the band mode setting to automatic. The enumeration of the modes
is slightly less broken after the previous commit, BUT band mode 0
should be in this list... always. all the time.

Signed-off-by: nuclearmistake <nuclearmistake@gmail.com>

Change-Id: I5082b04ee63a2916941fd1db40762fa990d59583