### PR TITLE
Allow restricted profiles on phones

### DIFF
--- a/src/com/android/settings/users/UserSettings.java
+++ b/src/com/android/settings/users/UserSettings.java
@@ -1056,8 +1056,8 @@ public class UserSettings extends SettingsPreferenceFragment
             caps.mIsAdmin = myUserInfo.isAdmin();
             DevicePolicyManager dpm = (DevicePolicyManager) context.getSystemService(
                     Context.DEVICE_POLICY_SERVICE);
-            // No restricted profiles for tablets with a device owner, or phones.
-            if (dpm.isDeviceManaged() || Utils.isVoiceCapable(context)) {
+            // No restricted profiles for devices with a device owner.
+            if (dpm.isDeviceManaged()) {
                 caps.mCanAddRestrictedProfile = false;
             }
             caps.updateAddUserCapabilities(context);


### PR DESCRIPTION
This restriction was introduced by commit 9e6ac3d25f55303887293e36eb288ef191ffd1bb
While it works normally on phones, disallowing calls will still
allow a restricted user to place emergency calls and receive any incoming
calls.

Change-Id: I61d5b80f0320445cc414d348342280d4eee3c304