### PR TITLE
Settings: per-app cellular data and wifi restrictions

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -423,4 +423,16 @@
     <string name="crypt_keeper_choose_your_password_header">Set encryption password</string>
     <string name="crypt_keeper_replace_password_title">Replace encryption password</string>
     <string name="crypt_keeper_replace_password_summary">Remove the separate encryption password</string>
+
+    <!-- Per-app data restrictions -->
+    <string name="data_usage_app_restrict_data_category_title">Cellular data access</string>
+    <string name="data_usage_app_restrict_wifi_category_title">Wi\u2011Fi data access</string>
+    <!-- Title for switch to block app data usage [CHAR LIMIT=30] -->
+    <string name="data_usage_app_restrict_all_data_title">Disable all cellular data access</string>
+    <!-- Summary for switch to block app data usage [CHAR LIMIT=NONE] -->
+    <string name="data_usage_app_restrict_all_data_summary">Prevent any use of data access via cellular networks</string>
+    <!-- Title for switch to block app data usage [CHAR LIMIT=30] -->
+    <string name="data_usage_app_restrict_all_wifi_title">Disable all Wi\u2011Fi data access</string>
+    <!-- Summary for switch to block app data usage [CHAR LIMIT=NONE] -->
+    <string name="data_usage_app_restrict_all_wifi_summary">Prevent any use of data access via Wi\u2011Fi networks</string>
 </resources>

--- a/res/xml/app_data_usage.xml
+++ b/res/xml/app_data_usage.xml
@@ -48,15 +48,37 @@
         android:key="app_settings"
         android:title="@string/data_usage_app_settings" />
 
-    <SwitchPreference
-        android:key="restrict_background"
-        android:title="@string/data_usage_app_restrict_background"
-        android:summary="@string/data_usage_app_restrict_background_summary" />
+    <PreferenceCategory
+        android:key="data_usage_app_restrict_data_category"
+        android:title="@string/data_usage_app_restrict_data_category_title" >
 
-    <SwitchPreference
-        android:key="unrestricted_data_saver"
-        android:title="@string/unrestricted_app_title"
-        android:summary="@string/unrestricted_app_summary" />
+        <SwitchPreference
+            android:key="restrict_background"
+            android:title="@string/data_usage_app_restrict_background"
+            android:summary="@string/data_usage_app_restrict_background_summary" />
+
+        <SwitchPreference
+            android:key="unrestricted_data_saver"
+            android:title="@string/unrestricted_app_title"
+            android:summary="@string/unrestricted_app_summary" />
+
+        <SwitchPreference
+            android:key="restrict_all_data"
+            android:title="@string/data_usage_app_restrict_all_data_title"
+            android:summary="@string/data_usage_app_restrict_all_data_summary" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="data_usage_app_restrict_wifi_category"
+        android:title="@string/data_usage_app_restrict_wifi_category_title" >
+
+        <SwitchPreference
+            android:key="restrict_all_wifi"
+            android:title="@string/data_usage_app_restrict_all_wifi_title"
+            android:summary="@string/data_usage_app_restrict_all_wifi_summary" />
+
+    </PreferenceCategory>
 
     <PreferenceCategory
         android:key="app_list"

--- a/src/com/android/settings/datausage/AppDataUsage.java
+++ b/src/com/android/settings/datausage/AppDataUsage.java
@@ -24,6 +24,7 @@ import android.content.pm.UserInfo;
 import android.graphics.drawable.Drawable;
 import android.net.INetworkStatsSession;
 import android.net.NetworkPolicy;
+import android.net.NetworkPolicyManager;
 import android.net.NetworkStatsHistory;
 import android.net.NetworkTemplate;
 import android.net.TrafficStats;
@@ -58,6 +59,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static android.net.NetworkPolicyManager.POLICY_REJECT_METERED_BACKGROUND;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_DATA;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_WIFI;
 
 public class AppDataUsage extends DataUsageBase implements Preference.OnPreferenceChangeListener,
         DataSaverBackend.Listener {
@@ -75,6 +78,8 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     private static final String KEY_APP_LIST = "app_list";
     private static final String KEY_CYCLE = "cycle";
     private static final String KEY_UNRESTRICTED_DATA = "unrestricted_data_saver";
+    private static final String KEY_RESTRICT_ALL_DATA = "restrict_all_data";
+    private static final String KEY_RESTRICT_ALL_WIFI = "restrict_all_wifi";
 
     private static final int LOADER_CHART_DATA = 2;
 
@@ -84,6 +89,8 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     private Preference mBackgroundUsage;
     private Preference mAppSettings;
     private SwitchPreference mRestrictBackground;
+    private SwitchPreference mRestrictAllData;
+    private SwitchPreference mRestrictAllWifi;
     private PreferenceCategory mAppList;
 
     private Drawable mIcon;
@@ -97,6 +104,7 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     private ChartData mChartData;
     private NetworkTemplate mTemplate;
     private NetworkPolicy mPolicy;
+    private NetworkPolicyManager mPolicyManager;
     private AppItem mAppItem;
     private Intent mAppSettingsIntent;
     private SpinnerPreference mCycle;
@@ -123,6 +131,8 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
         mAppItem = (args != null) ? (AppItem) args.getParcelable(ARG_APP_ITEM) : null;
         mTemplate = (args != null) ? (NetworkTemplate) args.getParcelable(ARG_NETWORK_TEMPLATE)
                 : null;
+        mPolicyManager = NetworkPolicyManager.from(getActivity());
+
         if (mTemplate == null) {
             Context context = getContext();
             mTemplate = DataUsageSummary.getDefaultTemplate(context,
@@ -167,11 +177,17 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
             if (!UserHandle.isApp(mAppItem.key)) {
                 removePreference(KEY_UNRESTRICTED_DATA);
                 removePreference(KEY_RESTRICT_BACKGROUND);
+                removePreference(KEY_RESTRICT_ALL_DATA);
+                removePreference(KEY_RESTRICT_ALL_WIFI);
             } else {
                 mRestrictBackground = (SwitchPreference) findPreference(KEY_RESTRICT_BACKGROUND);
                 mRestrictBackground.setOnPreferenceChangeListener(this);
                 mUnrestrictedData = (SwitchPreference) findPreference(KEY_UNRESTRICTED_DATA);
                 mUnrestrictedData.setOnPreferenceChangeListener(this);
+                mRestrictAllData = (SwitchPreference) findPreference(KEY_RESTRICT_ALL_DATA);
+                mRestrictAllData.setOnPreferenceChangeListener(this);
+                mRestrictAllWifi = (SwitchPreference) findPreference(KEY_RESTRICT_ALL_WIFI);
+                mRestrictAllWifi.setOnPreferenceChangeListener(this);
             }
             mDataSaverBackend = new DataSaverBackend(getContext());
             mAppSettings = findPreference(KEY_APP_SETTINGS);
@@ -224,6 +240,8 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
             removePreference(KEY_APP_SETTINGS);
             removePreference(KEY_RESTRICT_BACKGROUND);
             removePreference(KEY_APP_LIST);
+            removePreference(KEY_RESTRICT_ALL_DATA);
+            removePreference(KEY_RESTRICT_ALL_WIFI);
         }
     }
 
@@ -264,6 +282,12 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
         } else if (preference == mUnrestrictedData) {
             mDataSaverBackend.setIsWhitelisted(mAppItem.key, mPackageName, (Boolean) newValue);
             return true;
+        } else if (preference == mRestrictAllData) {
+            setAppRestrictAllData((boolean) newValue);
+            return true;
+        } else if (preference == mRestrictAllWifi) {
+            setAppRestrictAllWifi((boolean) newValue);
+            return true;
         }
         return false;
     }
@@ -280,20 +304,36 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     }
 
     private void updatePrefs() {
-        updatePrefs(getAppRestrictBackground(), getUnrestrictData());
+        updatePrefs(getAppRestrictBackground(), getUnrestrictData(),
+                getAppRestrictAllData(), getAppRestrictAllWifi());
     }
 
-    private void updatePrefs(boolean restrictBackground, boolean unrestrictData) {
+    private void updatePrefs(boolean restrictBackground, boolean unrestrictData,
+            boolean restrictAllData, boolean restrictAllWifi) {
         if (mRestrictBackground != null) {
-            mRestrictBackground.setChecked(!restrictBackground);
+            if (restrictAllData) {
+                mRestrictBackground.setEnabled(false);
+                mRestrictBackground.setChecked(false);
+            } else {
+                mRestrictBackground.setEnabled(true);
+                mRestrictBackground.setChecked(!restrictBackground);
+            }
         }
         if (mUnrestrictedData != null) {
-            if (restrictBackground) {
-                mUnrestrictedData.setVisible(false);
+            if (restrictAllData || restrictBackground) {
+                mUnrestrictedData.setEnabled(false);
+                mUnrestrictedData.setChecked(false);
             } else {
-                mUnrestrictedData.setVisible(true);
+                mUnrestrictedData.setEnabled(true);
                 mUnrestrictedData.setChecked(unrestrictData);
             }
+        }
+
+        if (mRestrictAllData != null) {
+            mRestrictAllData.setChecked(restrictAllData);
+        }
+        if (mRestrictAllWifi != null) {
+            mRestrictAllWifi.setChecked(restrictAllWifi);
         }
     }
 
@@ -339,6 +379,37 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
             return mDataSaverBackend.isWhitelisted(mAppItem.key);
         }
         return false;
+    }
+
+    private boolean getAppRestrictAllData() {
+        return getAppRestriction(POLICY_REJECT_ON_DATA);
+    }
+
+    private boolean getAppRestrictAllWifi() {
+        return getAppRestriction(POLICY_REJECT_ON_WIFI);
+    }
+
+    private boolean getAppRestriction(int policy) {
+        final int uid = mAppItem.key;
+        final int uidPolicy = services.mPolicyManager.getUidPolicy(uid);
+        return (uidPolicy & policy) != 0;
+    }
+
+    private void setAppRestrictAllData(boolean restrict) {
+        setAppRestriction(POLICY_REJECT_ON_DATA, restrict);
+    }
+
+    private void setAppRestrictAllWifi(boolean restrict) {
+        setAppRestriction(POLICY_REJECT_ON_WIFI, restrict);
+    }
+
+    private void setAppRestriction(int policy, boolean restrict) {
+        final int uid = mAppItem.key;
+        if (restrict) {
+            mPolicyManager.addUidPolicy(uid, policy);
+        } else {
+            mPolicyManager.removeUidPolicy(uid, policy);
+        }
     }
 
     @Override
@@ -430,14 +501,16 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     @Override
     public void onWhitelistStatusChanged(int uid, boolean isWhitelisted) {
         if (mAppItem.uids.get(uid, false)) {
-            updatePrefs(getAppRestrictBackground(), isWhitelisted);
+            updatePrefs(getAppRestrictBackground(), isWhitelisted,
+                    getAppRestrictAllData(), getAppRestrictAllWifi());
         }
     }
 
     @Override
     public void onBlacklistStatusChanged(int uid, boolean isBlacklisted) {
         if (mAppItem.uids.get(uid, false)) {
-            updatePrefs(isBlacklisted, getUnrestrictData());
+            updatePrefs(isBlacklisted, getUnrestrictData(),
+                    getAppRestrictAllData(), getAppRestrictAllWifi());
         }
     }
 }


### PR DESCRIPTION
*) Add options to disable all cellular data and all wifi data
   in app data usage settings.

*) Disable the existing background data and unrestricted
   data usage options when all cellular data access is
   disabled.

This is a replacement for the appops menu based cell/wifi data
restriction settings in cm-13.0:
Author: Danesh M <daneshm90@gmail.com>
Date:   Mon Mar 7 15:17:59 2016 -0800
    Settings : Add per app internet/data control
    CYAN-3976
    CRACKLING-834
    Change-Id: I13192df837c057b5cadde8f31532e12daaf3c1b0

Change-Id: Ic087c27a5ed0bdb84bb8f297c425c6bcbffec848