### PR TITLE
[3/3] Settings: Add CMParts charging sound settings preference

### DIFF
--- a/res/xml/other_sound_settings.xml
+++ b/res/xml/other_sound_settings.xml
@@ -15,6 +15,7 @@
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:lineage="http://schemas.android.com/apk/res/cyanogenmod.platform"
         android:title="@string/other_sound_settings"
         android:key="other_sound_settings"
         xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
@@ -33,6 +34,11 @@
     <SwitchPreference
             android:key="charging_sounds"
             android:title="@string/charging_sounds_title" />
+
+    <!-- Custom charging sounds -->
+    <org.cyanogenmod.internal.cmparts.CMPartsPreference
+            android:key="charging_sounds_settings"
+            lineage:replacesKey="charging_sounds" />
 
     <!-- Docking sounds -->
     <SwitchPreference


### PR DESCRIPTION
Replace the existing AOSP setting with this.

Change-Id: I13894a86bcfad8d1dfaedc2dcbca6ad70f651b5c