### PR TITLE
Handle SubSettings instance leaks in Index.java

### DIFF
--- a/src/com/android/settings/search/Index.java
+++ b/src/com/android/settings/search/Index.java
@@ -218,18 +218,18 @@ public class Index {
      */
     public static Index getInstance(Context context) {
         if (sInstance == null) {
-            sInstance = new Index(context.getApplicationContext(), BASE_AUTHORITY);
+            synchronized (Index.class) {
+                if (sInstance == null) {
+                    sInstance = new Index(context.getApplicationContext(), BASE_AUTHORITY);
+                }
+            }
         }
         return sInstance;
     }
 
-    public Index(Context context, String baseAuthority) {
+    private Index(Context context, String baseAuthority) {
         mContext = context;
         mBaseAuthority = baseAuthority;
-    }
-
-    public void setContext(Context context) {
-        mContext = context;
     }
 
     public boolean isAvailable() {


### PR DESCRIPTION
Index's constructor will hold context of caller.
context.getApplicationContext() instead of context to prevent activity
leaks.

Bug: https://code.google.com/p/android/issues/detail?id=223322

Test: manual-start a new activity call Index constructor ,then pressed
back.

Change-Id: Ic12af62f9b718d328610a57985f64ca4629bab99
Signed-off-by: gaochong <gaochong@xiaomi.com>